### PR TITLE
Add simple cmd classification

### DIFF
--- a/sfctl-ai/src/cmd_parse.rs
+++ b/sfctl-ai/src/cmd_parse.rs
@@ -1,0 +1,47 @@
+#[derive(Debug, PartialEq, Eq)]
+pub enum CmdKind {
+    Read,
+    Write,
+    Unknown,
+}
+
+/// Simple heuristic to classify PowerShell commands into Read, Write, or Unknown
+pub fn classify_cmd(cmd: &str) -> CmdKind {
+    let cmd = cmd.trim_start();
+
+    // Special cases
+    if cmd.starts_with("Import-Module") {
+        return CmdKind::Read;
+    }
+
+    if cmd.contains("|") {
+        CmdKind::Unknown // Don't classify piped commands
+    } else if cmd.starts_with("Get-") || cmd.starts_with("Select-") || cmd.starts_with("Read-") {
+        CmdKind::Read
+    } else if cmd.starts_with("Set-")
+        || cmd.starts_with("New-")
+        || cmd.starts_with("Add-")
+        || cmd.starts_with("Remove-")
+        || cmd.starts_with("Update-")
+        || cmd.starts_with("Write-")
+    {
+        CmdKind::Write
+    } else {
+        CmdKind::Unknown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_classify_cmd() {
+        assert_eq!(classify_cmd("Import-Module ServiceFabric"), CmdKind::Read);
+        assert_eq!(classify_cmd("Restart-ServiceFabricNode"), CmdKind::Unknown);
+        assert_eq!(
+            classify_cmd("Connect-ServiceFabricCluster"),
+            CmdKind::Unknown
+        );
+    }
+}

--- a/sfctl-ai/src/lib.rs
+++ b/sfctl-ai/src/lib.rs
@@ -1,6 +1,7 @@
 use tokio_util::sync::CancellationToken;
 pub mod ack;
 pub mod ai;
+pub mod cmd_parse;
 pub mod model;
 pub mod pwsh;
 

--- a/sfctl-ai/src/pwsh.rs
+++ b/sfctl-ai/src/pwsh.rs
@@ -23,13 +23,18 @@ impl PwshSession {
         Ok(PwshSession { stdin, stdout })
     }
 
-    pub async fn run_command(&mut self, command: &str) -> std::io::Result<String> {
-        // Remove comments from command
-        let command = command
+    /// Trim comments (lines starting with #) from the command
+    pub fn trim_command(command: &str) -> String {
+        command
             .lines()
             .filter(|line| !line.trim().starts_with('#'))
             .collect::<Vec<&str>>()
-            .join("\n");
+            .join("\n")
+    }
+
+    pub async fn run_command(&mut self, command: &str) -> std::io::Result<String> {
+        // Remove comments from command
+        let command = Self::trim_command(command);
 
         // Use Invoke-Command with a marker to simplify parsing
         let marker = "___COMMAND_END___";

--- a/sfctl-ai/src/system_prompt.txt
+++ b/sfctl-ai/src/system_prompt.txt
@@ -24,7 +24,9 @@ In the chat session do these once:
 For local cluster use the default value localhost:19000, and do not prompt, but just execute the command with default value.
 
 Other notes:
-If a command returns an empty string it can also mean it succeeded. Do not retry, but ask user for next steps.
-If a Get-<Command> returns empty string it means that it succeeded and no entity exists. Do not retry again, but ask user for next steps.
-If some command fails in pwsh because it needs user confirmation in NonInteractive mode, try add -Force parameter to bypass confirmation.
+* If a command returns an empty string it can also mean it succeeded. Do not retry, but ask user for next steps.
+* If a Get-<Command> returns empty string it means that it succeeded and no entity exists. Do not retry again, but ask user for next steps.
+* If some command fails in pwsh because it needs user confirmation in NonInteractive mode, try add -Force parameter to bypass confirmation.
+* Do not join multiple command using pipes, run each command one at a time:
+For example do not use `Get-ServiceFabricService -ApplicationName fabric:/System | Select-Object -Property ServiceName -First 1`. Run `Get-ServiceFabricService -ApplicationName fabric:/System` seperately.
 


### PR DESCRIPTION
Tool can run read only commands without user prompt.
The classification may reject more commands than needed for safety.