### PR TITLE
Add mcp.json in vscode dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 target
 *.info
 codecov.json
-.vscode
 logs
+
+.vscode/*
+!.vscode/mcp.json

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,14 @@
+{
+  "servers": {
+    "sfctl-ai-server": {
+      "type": "stdio",
+      "command": "${workspaceFolder}/target/debug/sfctl-ai-mcp.exe",
+      "cwd": "${workspaceFolder}",
+      "args": [],
+      "env": {
+        "RUST_LOG": "debug"
+      }
+    }
+  },
+  "inputs": []
+}

--- a/README.md
+++ b/README.md
@@ -32,31 +32,12 @@ First, ensure you have a local Service Fabric cluster running:
 
 ```bash
 cd sfctl-ai/sfctl-ai
-cargo build --release
-cargo install --path . --bin sfctl-ai-mcp
+cargo build --bin sfctl-ai-mcp
 ```
 
 ### 3. Configure VS Code
 
-Create `.vscode/mcp.json` in your workspace:
-
-```json
-{
-  "servers": {
-    "sfctl-ai-server": {
-      "type": "stdio",
-      "command": "C:\\Users\\[USERNAME]\\.cargo\\bin\\sfctl-ai-mcp.exe",
-      "args": [],
-      "env": {
-        "RUST_LOG": "debug"
-      }
-    }
-  },
-  "inputs": []
-}
-```
-
-**Note**: Replace `[USERNAME]` with your actual Windows username. The full path ensures VS Code can find the executable.
+Use the default `.vscode/mcp.json` in the current vscode workspace.
 
 **Note**: The `RUST_LOG: debug` environment variable helps with troubleshooting if needed.
 


### PR DESCRIPTION
Add the mcp.json so that after clone and build, one can directly test the mcp in vscode.